### PR TITLE
Add HSS as kernel extension

### DIFF
--- a/linux/Config.ext.in
+++ b/linux/Config.ext.in
@@ -138,4 +138,11 @@ config BR2_LINUX_KERNEL_EXT_AUFS_VERSION
 
 endif # aufs
 
+config BR2_LINUX_KERNEL_EXT_HSS
+	select BR2_PACKAGE_HSS
+	bool "Host Socket Sharing Headers"
+
+	help
+	  Build USB HSS into the kernel.
+
 endmenu

--- a/linux/linux-ext-hss.mk
+++ b/linux/linux-ext-hss.mk
@@ -1,0 +1,16 @@
+################################################################################
+#
+# hss
+#
+################################################################################
+
+LINUX_EXTENSIONS += hss
+ifeq ($(BR2_CONFIG_SECURITY_SELINUX),y)
+define HSS_SELINUX_PATCH
+	hss-selinux.patch
+endef
+endif
+
+define HSS_PREPARE_KERNEL
+	$(APPLY_PATCHES) $(LINUX_DIR) $(HSS_DIR)/device/kernel hss-includes.patch hss-socket.patch $(HSS_SELINUX_PATCH)
+endef


### PR DESCRIPTION
Due to the way Buildroot requires kernel changes to be structures this must be placed in this repo. We want to upstream the other repos anyways so I'm open to moving everything here as well. 